### PR TITLE
Update interfacePegarDados.php

### DIFF
--- a/interfacePegarDados.php
+++ b/interfacePegarDados.php
@@ -2,9 +2,5 @@
 
 interface pegarDados
 {
-
-	public function obterDados (string $url): string;
-	
-	//A função retornará uma closure, para ser usada  a callback necessaria para limitar o download dos dados.
-	public function dividirDadosClosure(): closure;
+    public function obterDados (string $url): string;
 }


### PR DESCRIPTION
Removido o método dividirDadosClosure, pois, não é necessário. O mesmo será implementado direto na classe abstrata, já que não há necessidade da classe saber sobre a implantação do mesmo, ela precisa saber obter os dados.